### PR TITLE
Execute streamlit script inside the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN pip3 install --requirement requirements.txt
 
 RUN streamlit version
 
-CMD ["streamlit", "hello"]
+CMD ["streamlit", "run", "app.py"]


### PR DESCRIPTION
Replace streamlit hello example with the covid-19 streamlit app inside the container.
This PR requires the docker image to be recreated, by rerun `make image` after updating your local repo.