### PR TITLE
Copy missing repo content to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py \
     && python3 get-pip.py \
     && rm get-pip.py
 
-COPY ./requirements.txt ./
+COPY ./ ./
 
 RUN pip3 install --requirement requirements.txt
 


### PR DESCRIPTION
The built image was missing the repo content, so the app.py didn't exist
within the image at docker hub registry.