### PR TITLE
Run tests in our C.I. checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,10 @@ covid-19: ## Run covid-19 container
 image: ## Build covid-19 image
 	docker build . --tag $(image)
 
+.PHONY: test
 test:
+ifneq "$(shell which pytest)" ""
 	pytest --doctest-modules --verbose covid19/
+else
+	docker run --rm $(image) pytest --doctest-modules --verbose covid19/
+endif

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,5 @@
 steps:
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '.',
-    '-t', 'test',
-    '-t', 'gcr.io/$PROJECT_ID/covid19:$SHORT_SHA']
+  args: ['build', '.', '-t', 'test']
 - name: test
   args: ['pytest', '--doctest-modules', '--verbose', 'covid19/']
-
-images:
-- gcr.io/$PROJECT_ID/covid19:$SHORT_SHA

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,10 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '.',
+    '-t', 'test',
+    '-t', 'gcr.io/$PROJECT_ID/covid19:$SHORT_SHA']
+- name: test
+  args: ['pytest', '--doctest-modules', '--verbose', 'covid19/']
+
+images:
+- gcr.io/$PROJECT_ID/covid19:$SHORT_SHA


### PR DESCRIPTION
#### Issue
Our [cloudbuild](https://cloud.google.com/cloud-build) CI was only checking if the [Dockerfile](./Dockerfile) still successfully builds.
We could always keep checking if the **tests** are **passing** there too!

#### Solution
Now, beyond building the image, it is running the `make test`<sup>1 2</sup> step reporting it as status checks.

#### Observations
[1] Took the chance to adjust make `test` target to use covid-19 image if pytest is not installed locally, and [phony](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) it too.
[2] Could not use make test itself because the covid-19 image doesn't have GNU make installed, so had to call pytest directly