### PR TITLE
fixes bug in viz granularity was always municipio

### DIFF
--- a/simulator/pages/seir.py
+++ b/simulator/pages/seir.py
@@ -257,7 +257,7 @@ def write():
                      DEFAULT_STATE)
 
     options_place = make_place_options(cases_df, population_df)
-    w_place = st.sidebar.selectbox('Município',
+    w_place = st.sidebar.selectbox(f'{global_format_func(w_granularity)}',
                                    options=options_place,
                                    index=options_place.get_loc(DEFAULT_PLACE),
                                    format_func=global_format_func)


### PR DESCRIPTION
No app online atualmente a granularidade escolhida não afeta o título do selectbox logo em seguida, que estava fixado em "Municipio"
![image](https://user-images.githubusercontent.com/20524003/80148645-c0cf9780-858b-11ea-941c-e5da06a76139.png)

Alterei o texto do selectbox para variar conforme a unidade escolhida:
![image](https://user-images.githubusercontent.com/20524003/80148733-de046600-858b-11ea-8fee-dec7fec22365.png)
